### PR TITLE
Bugfix/crash in ares  sortaddrinfo

### DIFF
--- a/src/lib/ares__sortaddrinfo.c
+++ b/src/lib/ares__sortaddrinfo.c
@@ -453,6 +453,10 @@ int ares__sortaddrinfo(ares_channel channel, struct ares_addrinfo_node *list_sen
       ++nelem;
       cur = cur->ai_next;
     }
+
+  if (!nelem)
+      return ARES_ENODATA;
+
   elems = (struct addrinfo_sort_elem *)ares_malloc(
       nelem * sizeof(struct addrinfo_sort_elem));
   if (!elems)

--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -393,7 +393,7 @@ static void end_hquery(struct host_query *hquery, int status)
   struct ares_addrinfo_node *next;
   if (status == ARES_SUCCESS)
     {
-      if (!(hquery->hints.ai_flags & ARES_AI_NOSORT))
+      if (!(hquery->hints.ai_flags & ARES_AI_NOSORT) && hquery->ai->nodes)
         {
           sentinel.ai_next = hquery->ai->nodes;
           ares__sortaddrinfo(hquery->channel, &sentinel);


### PR DESCRIPTION
These patch set contains the following:
* fix crash in `ares__sortaddrinfo` when sending an empty list
* prevent sorting the hosts list if it's empty